### PR TITLE
Fix NPE in get-capsule-output-dir

### DIFF
--- a/src/leiningen/capsule/utils.clj
+++ b/src/leiningen/capsule/utils.clj
@@ -173,5 +173,5 @@
 
 (defn ^:internal get-capsules-output-dir [project]
   "Computes the capsules output dir starting from the project target folder based on specification or sensible defaults"
-  (str (:target-path project) "/" (or (.toString (get-in project (cons :capsule cc/path-output-dir))) "capsules")))
+  (str (:target-path project) "/" (or (get-in project (cons :capsule cc/path-output-dir)) "capsules")))
 


### PR DESCRIPTION
Perhaps I had misconfigured something but this was calling `.toString`
on `nil`.  In any event, this code is a bit cleaner. `str` will call
`.toString` so we don't have to.